### PR TITLE
Simplify plugin installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,22 +27,17 @@ cargo build --release
 
 ### Claude Code Plugin
 
+Install directly from GitHub:
 ```bash
-# Clone this repository
-git clone https://github.com/cloud-atlas-ai/ba.git
-cd ba
-
-# Add ba marketplace from local directory
-claude plugin marketplace add $PWD
-
-# Install ba plugin (includes Codex skill)
+claude plugin marketplace add https://github.com/cloud-atlas-ai/ba
 claude plugin install ba@ba
 ```
 
-After [PR #1](https://github.com/cloud-atlas-ai/ba/pull/1) merges to master:
+Or install from local clone:
 ```bash
-# Simpler: install directly from GitHub
-claude plugin marketplace add https://github.com/cloud-atlas-ai/ba
+git clone https://github.com/cloud-atlas-ai/ba.git
+cd ba
+claude plugin marketplace add $PWD
 claude plugin install ba@ba
 ```
 


### PR DESCRIPTION
## Summary

Minor documentation cleanup: simplifies plugin installation instructions in README.md by removing conditional \"After PR #1 merges\" text.

### Changes

- Remove \"After [PR #1] merges to master:\" conditional text
- Make GitHub URL installation the primary method
- Show local clone installation as alternative
- Both methods are tested and working

### Before
```
# Clone this repository
git clone...
claude plugin marketplace add $PWD
...

After [PR #1](https://github.com/cloud-atlas-ai/ba/pull/1) merges to master:
# Simpler: install directly from GitHub
claude plugin marketplace add https://github.com/cloud-atlas-ai/ba
...
```

### After
```
Install directly from GitHub:
claude plugin marketplace add https://github.com/cloud-atlas-ai/ba
...

Or install from local clone:
git clone...
```

### Testing

- [x] Tested GitHub URL installation method  
- [x] Tested local clone installation method

Both work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)